### PR TITLE
pause on startup to enable debugging of startup issues

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,6 +38,7 @@ let executableArgs = [
 // The Mac and Linux runtimes accept either -jsdebugger or --jsdebugger,
 // but Windows needs the former, so we use it for all platforms.
 options.jsdebugger && executableArgs.push('-jsdebugger');
+options.jsdebugger && executableArgs.push('--pause-on-startup');
 
 process.env.MOZ_NO_REMOTE = 1;
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,6 +27,7 @@ const { command, argv } = commandLineCommands(validCommands);
 const optionDefinitions = [
   { name: 'jsdebugger', type: Boolean },
   { name: 'path', type: String, defaultOption: true },
+  { name: 'pause-on-startup', type: Boolean },
 ];
 const options = commandLineArgs(optionDefinitions, { argv: argv });
 
@@ -52,7 +53,7 @@ let executableArgs = [
 // The Mac and Linux runtimes accept either -jsdebugger or --jsdebugger,
 // but Windows needs the former, so we use it for all platforms.
 options.jsdebugger && executableArgs.push('-jsdebugger');
-options.jsdebugger && executableArgs.push('--pause-on-startup');
+options['pause-on-startup'] && executableArgs.push('--pause-on-startup');
 
 process.env.MOZ_NO_REMOTE = 1;
 

--- a/devtools-mac.manifest
+++ b/devtools-mac.manifest
@@ -1,4 +1,10 @@
+# The location of the jsinspector interface depends on how the runtime
+# is packaged.  In a downloaded nightly build, it's in interfaces.xpt,
+# while in a local build it's in jsinspector.xpt.  We cover both bases,
+# since nothing bad happens if one or the other file isn't found.
 interfaces dist/Runtime.app/Contents/Resources/browser/components/interfaces.xpt
+interfaces dist/Runtime.app/Contents/Resources/browser/components/jsinspector.xpt
+
 locale devtools en-US dist/Runtime.app/Contents/Resources/browser/chrome/en-US/locale/en-US/devtools/client/
 locale devtools-shared en-US dist/Runtime.app/Contents/Resources/browser/chrome/en-US/locale/en-US/devtools/shared/
 content devtools dist/Runtime.app/Contents/Resources/browser/chrome/devtools/content/

--- a/devtools.manifest
+++ b/devtools.manifest
@@ -1,4 +1,10 @@
+# The location of the jsinspector interface depends on how the runtime
+# is packaged.  In a downloaded nightly build, it's in interfaces.xpt,
+# while in a local build it's in jsinspector.xpt.  We cover both bases,
+# since nothing bad happens if one or the other file isn't found.
 interfaces dist/firefox/browser/components/interfaces.xpt
+interfaces dist/firefox/browser/components/jsinspector.xpt
+
 locale devtools en-US dist/firefox/browser/chrome/en-US/locale/en-US/devtools/client/
 locale devtools-shared en-US dist/firefox/browser/chrome/en-US/locale/en-US/devtools/shared/
 content devtools dist/firefox/browser/chrome/devtools/content/


### PR DESCRIPTION
This adds --pause-on-startup to the runtime command-line options if --jsdebugger is specified, which pauses the runtime until the devtools process has connected to it, so it's possible to debug startup issues via "debugger" statements.

I'm not sure this is actually the best way to do this, however. Perhaps better would be to enable qbrt developers to specify runtime arguments via some other flags, i.e. something like `qbrt run --runtime-args='--jsdebugger --pause-on-startup' foo.js`.
