### PR TITLE
rename pause-on-startup to wait-for-jsdebugger

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,7 +37,7 @@ function run() {
   const optionDefinitions = [
     { name: 'jsdebugger', type: Boolean },
     { name: 'path', type: String, defaultOption: true },
-    { name: 'pause-on-startup', type: Boolean },
+    { name: 'wait-for-jsdebugger', type: Boolean },
   ];
   const options = commandLineArgs(optionDefinitions, { argv: argv });
 
@@ -63,7 +63,7 @@ function run() {
   // The Mac and Linux runtimes accept either -jsdebugger or --jsdebugger,
   // but Windows needs the former, so we use it for all platforms.
   options.jsdebugger && executableArgs.push('-jsdebugger');
-  options['pause-on-startup'] && executableArgs.push('--pause-on-startup');
+  options['wait-for-jsdebugger'] && executableArgs.push('--wait-for-jsdebugger');
 
   process.env.MOZ_NO_REMOTE = 1;
 


### PR DESCRIPTION
Per the change over in https://bugzilla.mozilla.org/show_bug.cgi?id=1275942.