### PR TITLE
allow TaskCluster to build 'public' pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,5 @@
 version: 0
+allowPullRequests: public
 metadata:
   name: qbrt
   description: a Node CLI to a minimal Mozilla desktop app runtime


### PR DESCRIPTION
Over in #22, TaskCluster won't build because: "The `allowPullRequests` configuration for this repository (in `.taskcluster.yml` on the default branch) does not allow starting tasks for this pull request."

This branch fixes that problem by setting *allowPullRequests* to `public`.