### PR TITLE
enhancement: load `index.js` if `main` key is missing from app's `package.json`

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -218,7 +218,7 @@ new Promise((resolve, reject) => {
   return pify(extract)(browserJAR, { dir: targetDir });
 })
 .then(() => {
-  // Copy devtools pref files from browser to qbert.
+  // Copy devtools pref files from browser to qbrt.
 
   const sourceDir = path.join(resourcesDir, 'qbrt', 'browser', 'defaults', 'preferences');
   const targetDir = path.join(resourcesDir, 'qbrt', 'defaults', 'preferences');

--- a/components/CommandLineHandler.js
+++ b/components/CommandLineHandler.js
@@ -126,7 +126,7 @@ CommandLineHandler.prototype = {
       // This will break if packageJSON.main is a path rather than just a filename.
       // TODO: resolve path properly.
       let mainFile = webappDir.clone();
-      mainFile.append(packageJSON.main);
+      mainFile.append(packageJSON.main || 'index.js');
       aqqPath = mainFile;
     }
 

--- a/shell/main.js
+++ b/shell/main.js
@@ -33,7 +33,7 @@ if (Services.appinfo.OS === 'Darwin') {
   Cc['@mozilla.org/widget/macdocksupport;1'].getService(Ci.nsIMacDockSupport).activateApplication(true);
 }
 
-const url = Runtime.commandLineArgs[0] || Runtime.packageJSON.mainURL;
+const url = Runtime.commandLineArgs[0] || Runtime.packageJSON.mainURL || 'index.html';
 const argument = Cc['@mozilla.org/supports-string;1'].createInstance(Ci.nsISupportsString);
 argument.data = url;
 


### PR DESCRIPTION
Felt like this was just a good safety check.

And, while I know qbrt's seeking for parity with Electron, FWIW, Electron does the same thing in its [implementation](https://electron.atom.io/docs/tutorial/quick-start/):

> Note: If the `main` field is not present in `package.json`, Electron will attempt to load an `index.js`.
