### PR TITLE
enhancement: make example's `main.js` look more similar to that of an Electron entry point

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -9,14 +9,30 @@ const { Runtime } = Cu.import('resource://qbrt/modules/Runtime.jsm', {});
 const { Services } = Cu.import('resource://gre/modules/Services.jsm', {});
 
 const WINDOW_URL = 'chrome://app/content/index.html';
+const WINDOW_DEFAULTS = {
+  dialog: false,
+  width: 640,
+  height: 480
+};
 
-const WINDOW_FEATURES = [
-  'chrome',
-  'dialog=no',
-  'all',
-  'width=640',
-  'height=480',
-].join(',');
+function BrowserWindow (opts) {
+  opts = Object.assign({}, WINDOW_DEFAULTS, opts);
+  this.windowFeatures = () => {
+    return [
+      'chrome',
+      `dialog=${opts.dialog ? 'yes' : 'no'}`,
+      'all',
+      `width=${opts.width}`,
+      `height=${opts.height}`,
+    ].join(',');
+  };
+}
+BrowserWindow.prototype.loadURL = url => {
+  return Services.ww.openWindow(null, url, '_blank', this.windowFeatures(), null);
+};
+BrowserWindow.prototype.webContents = {
+  openDevTools: () => Runtime.openDevTools(win)
+};
 
 // On startup, activate ourselves, since starting up from Node doesn't do this.
 // TODO: do this by default for all apps started via Node.
@@ -26,5 +42,12 @@ if (Services.appinfo.OS === 'Darwin') {
 
 console.log('Hello, World!');
 
-const window = Services.ww.openWindow(null, WINDOW_URL, '_blank', WINDOW_FEATURES, null);
-Runtime.openDevTools(window);
+const win = new BrowserWindow({
+  width: 800,
+  height: 600
+});
+
+win.loadURL(WINDOW_URL);
+
+// Open the DevTools.
+win.webContents.openDevTools();


### PR DESCRIPTION
Not necessary, but for good measure, I thought it might be worth showing. Or could create multiple `example` directories for different setups? Thoughts?
