### PR TITLE
forward unknown command-line args to app

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -80,7 +80,7 @@ function runApp() {
     { name: 'path', alias: 'p', type: String, defaultOption: true, defaultValue: argv[0] || process.cwd() },
     { name: 'wait-for-jsdebugger', alias: 'w', type: Boolean },
   ];
-  const options = commandLineArgs(optionDefinitions, { argv: argv });
+  const options = commandLineArgs(optionDefinitions, { argv: argv, partial: true });
 
   const executableDir = process.platform === 'darwin' ? path.join(installDir, 'Contents', 'MacOS') : installDir;
   const executable = path.join(executableDir, `firefox${process.platform === 'win32' ? '.exe' : ''}`);
@@ -110,6 +110,7 @@ function runApp() {
     // TODO: figure out why we need 'new-instance' for it to work.
     '-new-instance',
     '-aqq', mainEntryPoint,
+    ...options._unknown,
   ];
 
   if (appDir === shellDir) {

--- a/test/app-command-line-args/main.js
+++ b/test/app-command-line-args/main.js
@@ -1,0 +1,23 @@
+/* Copyright 2017 Mozilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+'use strict';
+
+const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
+const { console } = Cu.import('resource://gre/modules/Console.jsm', {});
+const { Runtime } = Cu.import('resource://qbrt/modules/Runtime.jsm', {});
+const { Services } = Cu.import('resource://gre/modules/Services.jsm', {});
+
+console.log(JSON.stringify(Runtime.commandLineArgs));
+Services.startup.quit(Ci.nsIAppStartup.eForceQuit);

--- a/test/app-command-line-args/package.json
+++ b/test/app-command-line-args/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "app-command-line-args",
+  "main": "main.js"
+}

--- a/test/run-command-line-args.js
+++ b/test/run-command-line-args.js
@@ -25,6 +25,11 @@ const tap = require('tap');
 
 let exitCode = 0;
 
+// Strangely, the runtime changes --foo to -foo on Mac/Linux but not Windows.
+const expectedOutput = process.platform === 'win32' ?
+  'console.log: ["test/app-command-line-args/","--foo","bar"]' :
+  'console.log: ["test/app-command-line-args/","-foo","bar"]';
+
 new Promise((resolve, reject) => {
   // Paths are relative to the top-level directory in which `npm test` is run.
   const child = spawn('node', [ path.join('bin', 'cli.js'), 'run',  'test/app-command-line-args/', '--foo', 'bar' ]);
@@ -42,7 +47,7 @@ new Promise((resolve, reject) => {
   });
 
   child.on('close', code => {
-    tap.equal(totalOutput, 'console.log: ["test/app-command-line-args/","-foo","bar"]');
+    tap.equal(totalOutput, expectedOutput);
     tap.equal(code, 0, 'app exited with success code');
   });
 

--- a/test/run-command-line-args.js
+++ b/test/run-command-line-args.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/* Copyright 2017 Mozilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+'use strict';
+
+// Polyfill Promise.prototype.finally().
+require('promise.prototype.finally').shim();
+
+const path = require('path');
+const spawn = require('child_process').spawn;
+const tap = require('tap');
+
+let exitCode = 0;
+
+new Promise((resolve, reject) => {
+  // Paths are relative to the top-level directory in which `npm test` is run.
+  const child = spawn('node', [ path.join('bin', 'cli.js'), 'run',  'test/app-command-line-args/', '--foo', 'bar' ]);
+
+  let totalOutput = '';
+
+  child.stdout.on('data', data => {
+    const output = data.toString('utf8').trim();
+    console.log(output);
+    totalOutput += output;
+  });
+
+  child.stderr.on('data', data => {
+    console.error(data.toString('utf8').trim());
+  });
+
+  child.on('close', code => {
+    tap.equal(totalOutput, 'console.log: ["test/app-command-line-args/","-foo","bar"]');
+    tap.equal(code, 0, 'app exited with success code');
+  });
+
+  child.on('close', (code, signal) => {
+    resolve();
+  });
+})
+.catch(error => {
+  console.error(error);
+  exitCode = 1;
+})
+.finally(() => {
+  process.exit(exitCode);
+});


### PR DESCRIPTION
This forwards unknown command-line args to the app. We could require the user to specify a single hypen (-) on the command-line before such args, which would be consistent with some other CLI tools. Unsure if that's necessary.