### PR TITLE
update to command-line-args w/default option/value fix

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -77,7 +77,7 @@ switch (command) {
 function runApp() {
   const optionDefinitions = [
     { name: 'jsdebugger', alias: 'd', type: Boolean },
-    { name: 'path', alias: 'p', type: String, defaultOption: true, defaultValue: argv[0] || process.cwd() },
+    { name: 'path', alias: 'p', type: String, defaultOption: true, defaultValue: process.cwd() },
     { name: 'wait-for-jsdebugger', alias: 'w', type: Boolean },
   ];
   const options = commandLineArgs(optionDefinitions, { argv: argv, partial: true });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "archiver": "^1.3.0",
     "chalk": "^1.1.3",
     "cli": "^1.0.1",
-    "command-line-args": "4.0.1",
+    "command-line-args": "^4.0.3",
     "command-line-commands": "^2.0.0",
     "command-line-usage": "^4.0.0",
     "decompress": "^4.0.0",

--- a/test/run-command-line-args.js
+++ b/test/run-command-line-args.js
@@ -26,9 +26,7 @@ const tap = require('tap');
 let exitCode = 0;
 
 // Strangely, the runtime changes --foo to -foo on Mac/Linux but not Windows.
-const expectedOutput = process.platform === 'win32' ?
-  'console.log: ["test/app-command-line-args/","--foo","bar"]' :
-  'console.log: ["test/app-command-line-args/","-foo","bar"]';
+const expectedOutput = process.platform === 'win32' ? 'console.log: ["--foo","bar"]' : 'console.log: ["-foo","bar"]';
 
 new Promise((resolve, reject) => {
   // Paths are relative to the top-level directory in which `npm test` is run.


### PR DESCRIPTION
command-line-args 4.0.1 used the default value for a default option
instead of one specified on the command line because of
<https://github.com/75lb/command-line-args/issues/47>, which we worked around
by setting the default value to the one specified on the command line.

command-line-args 4.0.3 fixes that problem, but in the process
it introduces a new one: if you specify the same value on the command line
as the default value, then command-line-args ignores the value
and sets the option to the next unknown value on the command line
<https://github.com/75lb/command-line-args/pull/48>.

Since our workaround makes the default value the same as the one specified
on the command line, it runs into that bug.  Fortunately, with 4.0.3,
we can stop setting the default value to the one specified on the command line,
resolving this problem (except in the rare event that the one specified
on the command line happens to be the same as the true default value, which is
the absolute path to the current working directory).

So this commit updates command-line-args to 4.0.3 and removes the workaround.
It also changes the test output to reflect that command-line-args no longer
includes the value of the default option in its list of "unknown args"
(which it should never have done but was previously doing, although I don't
know of an issue, PR, or commit that explicitly references or addresses it).