### PR TITLE
add --debug flag for debugging the runtime itself

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -132,6 +132,10 @@ function runApp() {
 
   if (options.debug) {
     switch (process.platform) {
+      case 'win32':
+        console.error('The --debug option is not yet supported on Windows.');
+        process.exit(1);
+        break;
       case 'darwin':
         executableArgs.unshift(executable, '--');
         executable = 'lldb';

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -131,8 +131,16 @@ function runApp() {
   const spawnOptions = {};
 
   if (options.debug) {
-    executableArgs.unshift(executable, '--');
-    executable = 'lldb';
+    switch (process.platform) {
+      case 'darwin':
+        executableArgs.unshift(executable, '--');
+        executable = 'lldb';
+        break;
+      case 'linux':
+        executableArgs.unshift('--args', executable);
+        executable = 'gdb';
+        break;
+    }
     spawnOptions.stdio = 'inherit';
   }
 


### PR DESCRIPTION
As with `--jsdebugger` and `--wait-for-jsdebugger`, this `--debug` flag is intended for debugging the runtime itself, not applications created with the runtime. Thus it's hidden (not documented), so as to avoid confusing app developers who might think it's for debugging apps.

(We might want to document these flags in a separate section of the help output, so app developers can find out about them without being misled into using them.)