### PR TITLE
disable TaskCluster for Windows until we figure out its bustage

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,31 +6,31 @@ metadata:
   owner: '{{ event.head.user.email }}'
   source: '{{ event.head.repo.url }}'
 tasks:
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    metadata:
-      name: qbrt test Windows
-      description: qbrt automated test suite on Windows
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
-    workerType: "win2012r2"
-    extra:
-      github:
-        env: true
-        events:
-          - pull_request.opened
-          - pull_request.closed
-          - pull_request.synchronize
-          - pull_request.reopened
-          - push
-          - release
-    payload:
-      maxRunTime: 3600
-      command:
-          - "git clone {{event.head.repo.url}} repo"
-          - "cd repo"
-          - "git checkout {{event.head.repo.branch}}"
-          - "npm install"
-          - "npm test"
+#  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+#    metadata:
+#      name: qbrt test Windows
+#      description: qbrt automated test suite on Windows
+#      owner: "{{ event.head.user.email }}"
+#      source: "{{ event.head.repo.url }}"
+#    workerType: "win2012r2"
+#    extra:
+#      github:
+#        env: true
+#        events:
+#          - pull_request.opened
+#          - pull_request.closed
+#          - pull_request.synchronize
+#          - pull_request.reopened
+#          - push
+#          - release
+#    payload:
+#      maxRunTime: 3600
+#      command:
+#          - "git clone {{event.head.repo.url}} repo"
+#          - "cd repo"
+#          - "git checkout {{event.head.repo.branch}}"
+#          - "npm install"
+#          - "npm test"
 # Disable Linux until we can figure out why launching it via the shell script
 # causes the executable to segfault.
 # - provisionerId: '{{ taskcluster.docker.provisionerId }}'


### PR DESCRIPTION
TaskCluster for Windows is busted, apparently because of a generic-worker update from 8.0.1 to 8.4.1. Here's the comparison, although I don't see any particular reason for the bustage in there: https://github.com/taskcluster/generic-worker/compare/v8.0.1...v8.4.1

This branch disables TaskCluster for Windows until we can figure out the bustage.