### PR TITLE
Update taskcluster badge with new api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Activity Level](https://img.shields.io/badge/status-active-green.svg)
 ![Stability](https://img.shields.io/badge/stability-unstable-red.svg)
 ![Travis Status](https://travis-ci.org/mozilla/qbrt.svg?branch=master)
-![TaskCluster Status](https://github.taskcluster.net/v1/badge/mozilla/qbrt/master)
+[![Taskcluster Status](https://github.taskcluster.net/v1/repository/mozilla/qbrt/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla/qbrt/master/latest)
 [![Greenkeeper Status](https://badges.greenkeeper.io/mozilla/qbrt.svg)](https://greenkeeper.io/)
 
 qbrt: CLI to a Gecko desktop app runtime


### PR DESCRIPTION
We've added a way to link to the most recent task group in taskcluster. Figured I would update it everywhere that I see the current badge used.