### PR TITLE
support Windows paths with spaces

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -155,7 +155,7 @@ function packageApp() {
 
   // Check `productName` first since it's often used by Electron apps.
   // TODO: ensure `appName` can be used as directory/file name.
-  const appName = appPackageJson.productName || appPackageJson.name;
+  const appName = appPackageJson.productName || appPackageJson.name || 'application';
   const stageDirName = process.platform === 'darwin' ? `${appName}.app` : appName;
   const packageFile = `${appName}.` + { win32: 'zip', darwin: 'dmg', linux: 'tgz' }[process.platform];
 

--- a/components/CommandLineHandler.js
+++ b/components/CommandLineHandler.js
@@ -123,10 +123,10 @@ CommandLineHandler.prototype = {
       packageJsonFile.append('package.json');
       packageJSON = JSON.parse(readFile(packageJsonFile));
 
-      // This will break if packageJSON.main is a path rather than just a filename.
-      // TODO: resolve path properly.
-      let mainFile = webappDir.clone();
-      mainFile.append(packageJSON.main || 'index.js');
+      let webappDirURI = Services.io.newFileURI(webappDir);
+      let mainFileURI = Services.io.newURI(packageJSON.main || 'index.js', null, webappDirURI);
+      mainFileURI.QueryInterface(Ci.nsIFileURL);
+      let mainFile = mainFileURI.file;
       aqqPath = mainFile;
     }
 

--- a/launcher.bat
+++ b/launcher.bat
@@ -1,2 +1,2 @@
 SET INSTALL_PATH=%~dp0
-start "" %INSTALL_PATH%firefox.exe --app %INSTALL_PATH%qbrt\application.ini --new-instance
+start "" "%INSTALL_PATH%firefox.exe" --app "%INSTALL_PATH%qbrt\application.ini" --new-instance

--- a/modules/Runtime.jsm
+++ b/modules/Runtime.jsm
@@ -27,6 +27,10 @@ this.Runtime = {
   get packageJSON() { return global.packageJSON },
 
   start(appFile, commandLineArgs, packageJSON) {
+    // TODO: stop assuming that appFile is in the topmost directory of the app.
+    // Instead, either traverse the path backwards until we find the package
+    // manifest, or make the caller specify the app directory in addition to
+    // the app file.
     registerChromePrefix(appFile.parent);
 
     const systemPrincipal = Cc['@mozilla.org/systemprincipal;1'].createInstance(Ci.nsIPrincipal);

--- a/test/main-path/main.js
+++ b/test/main-path/main.js
@@ -1,0 +1,23 @@
+/* Copyright 2017 Mozilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+'use strict';
+
+const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
+const { console } = Cu.import('resource://gre/modules/Console.jsm', {});
+const { Services } = Cu.import('resource://gre/modules/Services.jsm', {});
+
+console.log('main.js found at path');
+
+Services.startup.quit(Ci.nsIAppStartup.eForceQuit);

--- a/test/main-path/package.json
+++ b/test/main-path/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "main-path",
+  "main": "./main.js"
+}

--- a/test/package-main-path.js
+++ b/test/package-main-path.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/* Copyright 2017 Mozilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+'use strict';
+
+// TODO: refactor this with the largely-identical test script package-path.js.
+
+// Polyfill Promise.prototype.finally().
+require('promise.prototype.finally').shim();
+
+// Require *pify* out of order so we can use it to promisify other modules.
+const pify = require('pify');
+
+const decompress = require('decompress');
+const extract = require('extract-zip');
+const fs = pify(require('fs-extra'));
+const os = require('os');
+const packageJson = require('../package.json');
+const path = require('path');
+const spawn = require('child_process').spawn;
+const tap = require('tap');
+
+const origWorkDir = process.cwd();
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `${packageJson.name}-`));
+const appDir = path.join(tempDir, process.platform === 'darwin' ? 'main-path.app' : 'main-path');
+const commandLineScript = path.join(origWorkDir, 'bin', 'cli.js');
+const helloWorldDir = path.join(origWorkDir, 'test', 'main-path');
+
+let exitCode = 0;
+
+// Change into the temp dir so the package gets written to there.
+process.chdir(tempDir);
+
+new Promise((resolve, reject) => {
+  const child = spawn('node', [commandLineScript, 'package', helloWorldDir]);
+
+  child.stdout.on('data', data => {
+    const output = data.toString('utf8');
+    console.log(output.trim());
+    // TODO: determine what package command should output and assert it does.
+  });
+
+  child.stderr.on('data', data => {
+    const error = data.toString('utf8');
+    console.error(error);
+    reject(error);
+  });
+
+  child.on('exit', code => {
+    tap.equal(code, 0);
+    resolve();
+  });
+})
+.then(() => {
+  if (process.platform === 'win32') {
+    const source = 'main-path.zip';
+    const destination = tempDir;
+    // return decompress(source, destination);
+    return pify(extract)(source, { dir: destination });
+  }
+  else if (process.platform === 'darwin') {
+    const mountPoint = path.join(tempDir, 'volume');
+    return new Promise((resolve, reject) => {
+      const dmgFile = 'main-path.dmg';
+      const child = spawn('hdiutil', ['attach', dmgFile, '-mountpoint', mountPoint, '-nobrowse']);
+      child.on('exit', resolve);
+      child.on('error', reject);
+    })
+    .then((code) => {
+      tap.equal(code, 0, 'app disk image (.dmg) attached');
+      const source = path.join(mountPoint, 'main-path.app');
+      const destination = appDir;
+      return fs.copy(source, destination);
+    })
+    .then(() => {
+      return new Promise((resolve, reject) => {
+        const child = spawn('hdiutil', ['detach', mountPoint]);
+        child.on('exit', resolve);
+        child.on('error', reject);
+      });
+    })
+    .then((code) => {
+      tap.equal(code, 0, 'app disk image (.dmg) detached');
+    });
+  }
+  else if (process.platform === 'linux') {
+    const source = 'main-path.tgz';
+    const destination = tempDir;
+    return decompress(source, destination);
+  }
+})
+.then(() => {
+  let executable, args = [], shell = false;
+
+  switch (process.platform) {
+    case 'win32':
+      // On Windows, the launcher script launches the runtime and then quits
+      // without waiting for the runtime process to exit, so we need to launch
+      // the runtime directly.
+      //
+      // TODO: figure out how to invoke the launcher rather than the runtime
+      // (which will probably require converting the launcher into something
+      // other than a batch script).
+      //
+      executable = path.join(appDir, 'firefox.exe');
+      args = ['--app', path.win32.resolve(path.join(appDir, 'qbrt/application.ini')), '--new-instance'];
+      shell = true;
+      break;
+    case 'darwin':
+      executable = path.join(appDir, 'Contents', 'MacOS', 'main-path');
+      break;
+    case 'linux':
+      executable = path.join(appDir, 'main-path');
+      break;
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, { shell: shell });
+
+    let totalOutput = '';
+    child.stdout.on('data', data => {
+      const output = data.toString('utf8');
+      totalOutput += output;
+      console.log(output.trim());
+    });
+
+    child.stderr.on('data', data => {
+      // Report error messages that Linux on Travis loves to excrete, such as:
+      // GLib-GObject-CRITICAL **: g_object_unref: assertion 'object->ref_count > 0' failed
+      console.error(data.toString('utf8').trim());
+    });
+
+    child.on('exit', (code, signal) => {
+      tap.equal(code, 0, 'app exited with success code');
+      tap.equal(totalOutput.trim(), 'console.log: main.js found at path');
+    });
+
+    child.on('close', (code, signal) => {
+      resolve();
+    });
+  });
+})
+.catch(error => {
+  console.error(error);
+  exitCode = 1;
+})
+.finally(() => {
+  process.chdir(origWorkDir);
+})
+.then(() => {
+  return fs.remove(tempDir);
+})
+.then(() => {
+  process.exit(exitCode);
+});


### PR DESCRIPTION
@dmarcos This branch fixes two issues when packaging an app via a username with spaces. It also fixes a third issue that occurs when the *main* property of package.json is a path (f.e. `./main.js`).