### PR TITLE
work around hdiutil bug

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -270,8 +270,9 @@ function packageApp() {
       const trashesDir = path.join(tempDir, '.Trashes');
       fs.ensureDirSync(trashesDir);
       return new Promise((resolve, reject) => {
-        // console.log('hdiutil', 'create', '-verbose', '-srcfolder', stageDir, '-srcfolder', trashesDir, packageFile);
-        const child = spawn('hdiutil', ['create', '-srcfolder', stageDir, '-srcfolder', trashesDir, packageFile], { stdio: 'inherit' });
+        const child = spawn('hdiutil',
+                            ['create', '-srcfolder', stageDir, '-srcfolder', trashesDir, packageFile],
+                            { stdio: 'inherit' });
         child.on('exit', resolve);
         // TODO: handle errors returned by hdiutil.
       });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,12 +25,14 @@ const commandLineArgs = require('command-line-args');
 const commandLineCommands = require('command-line-commands');
 const commandLineUsage = require('command-line-usage');
 const fs = require('fs-extra');
+const klaw = require('klaw');
 const os = require('os');
 const normalizePackageData = require('normalize-package-data');
 const packageJson = require('../package.json');
 const path = require('path');
 const pify = require('pify');
 const readPkgUp = require('read-pkg-up');
+const semver = require('semver');
 const spawn = require('child_process').spawn;
 
 const distDir = path.join(__dirname, '..', 'dist', process.platform);
@@ -267,14 +269,37 @@ function packageApp() {
   })
   .then(() => {
     if (process.platform === 'darwin') {
-      const trashesDir = path.join(tempDir, '.Trashes');
-      fs.ensureDirSync(trashesDir);
+      const hdiutilArgs = ['create', '-srcfolder', stageDir];
       return new Promise((resolve, reject) => {
-        const child = spawn('hdiutil',
-                            ['create', '-srcfolder', stageDir, '-srcfolder', trashesDir, packageFile],
-                            { stdio: 'inherit' });
-        child.on('exit', resolve);
-        // TODO: handle errors returned by hdiutil.
+        // macOS 10.9 (Mavericks) has a bug in hdiutil that causes image
+        // creation to fail with obscure error -5341.  The problem doesn't seem
+        // to exist in earlier and later macOS versions, and the workaround
+        // causes the image to be larger than necessary (due to padding
+        // that avoids a resize), so we only do it on macOS 10.9.
+        if (semver.major(os.release()) === 13) {
+          let totalSizeInBytes = 0;
+          klaw(stageDir)
+          .on('data', item => {
+            totalSizeInBytes += item.stats.size;
+          })
+          .on('end', () => {
+            // Tests succeed with padding as low as 15MiB on my macOS 10.9 VM.
+            const size = (Math.ceil(totalSizeInBytes/1024/1024) + 15) + 'm';
+            hdiutilArgs.push('-size', size);
+            resolve();
+          });
+        }
+        else {
+          resolve();
+        }
+      })
+      .then(() => {
+        return new Promise((resolve, reject) => {
+          hdiutilArgs.push(packageFile);
+          const child = spawn('hdiutil', hdiutilArgs, { stdio: 'inherit' });
+          child.on('exit', resolve);
+          // TODO: handle errors returned by hdiutil.
+        });
       });
     }
     else if (process.platform === 'linux') {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "decompress": "^4.0.0",
     "extract-zip": "^1.6.5",
     "fs-extra": "^3.0.0",
+    "klaw": "^1.3.1",
     "normalize-package-data": "^2.3.8",
     "pify": "^2.3.0",
     "promise.prototype.finally": "^2.0.1",
     "read-pkg-up": "^2.0.0",
+    "semver": "^5.3.0",
     "simple-plist": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
hdiutil fails to create a disk image from a source folder on some older macOS versions (like 10.9) because of the obscure error code -5341. A variety of discussions, including <https://discussions.apple.com/thread/5667409> and <https://discussions.apple.com/thread/4712306>, propose various workarounds, and this change employs a variant of one workaround: also copy an empty .Trashes folder to the disk image, which apparently prevents hdiutil from trying and failing to resize the image after creating it. hdiutil would create that folder anyway, so this doesn't change the outcome. It just works around the bug.