### PR TITLE
run qbrt tests in headless mode on Linux

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -48,6 +48,8 @@ tasks:
           - push
           - release
     payload:
+      env:
+        MOZ_HEADLESS: 1
       maxRunTime: 3600
       image: 'node:6'
       command:
@@ -63,6 +65,4 @@ tasks:
           git checkout {{event.head.sha}} &&
           npm install . &&
           node ./bin/postinstall.js &&
-          (Xvfb :2 -screen 0 1024x768x24 &) &&
-          export DISPLAY=:2 &&
           npm test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ os:
 
 # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
 before_script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export MOZ_HEADLESS=1; fi


### PR DESCRIPTION
Although we no longer have to run Xvfb on Linux, we still need to install libgtk-3-0, libdbus-glib-1-2, and xvfb on TaskCluster to avoid failing with errors like:

> XPCOMGlueLoad error for file /home/node/repo/dist/linux/runtime/libxul.so:
> libX11-xcb.so.1: cannot open shared object file: No such file or directory
> Couldn't load XPCOM.

@brendandahl Is that expected?
