### PR TITLE
Refactor the CLI to allow building windows and linux packages on any other platform

### DIFF
--- a/bin/directory-utils.js
+++ b/bin/directory-utils.js
@@ -3,7 +3,7 @@ function getPlatformDirectories(platform=process.platform) {
   const distDir = path.join(__dirname, '..', 'dist', platform);
   const installDir = path.join(distDir, platform === 'darwin' ? 'Runtime.app' : 'runtime');
   const resourcesDir = platform === 'darwin' ? path.join(installDir, 'Contents', 'Resources') : installDir;
-  const executableDir = process.platform === 'darwin' ? path.join(installDir, 'Contents', 'MacOS') : installDir;
+  const executableDir = platform === 'darwin' ? path.join(installDir, 'Contents', 'MacOS') : installDir;
   return { distDir, installDir, resourcesDir, executableDir };
 }
 module.exports = { getPlatformDirectories };

--- a/bin/directory-utils.js
+++ b/bin/directory-utils.js
@@ -1,0 +1,9 @@
+const path = require('path');
+function getPlatformDirectories(platform=process.platform) {
+  const distDir = path.join(__dirname, '..', 'dist', platform);
+  const installDir = path.join(distDir, platform === 'darwin' ? 'Runtime.app' : 'runtime');
+  const resourcesDir = platform === 'darwin' ? path.join(installDir, 'Contents', 'Resources') : installDir;
+  const executableDir = process.platform === 'darwin' ? path.join(installDir, 'Contents', 'MacOS') : installDir;
+  return { distDir, installDir, resourcesDir, executableDir };
+}
+module.exports = { getPlatformDirectories };

--- a/bin/install-runtime.js
+++ b/bin/install-runtime.js
@@ -43,7 +43,6 @@ const fileExtensions = {
   'application/x-tar': 'tar.bz2',
 };
 
-// TODO: Download architecture should not be based on current process architecture.
 function getDownloadOS(platform) {
   switch (platform) {
     case 'win32':

--- a/bin/install-xulapp.js
+++ b/bin/install-xulapp.js
@@ -24,18 +24,16 @@ const cli = require('cli');
 const fs = require('fs-extra');
 const path = require('path');
 const pify = require('pify');
+const { getPlatformDirectories } = require('./directory-utils');
 
-const distDir = path.join(__dirname, '..', 'dist', process.platform);
-const installDir = path.join(distDir, process.platform === 'darwin' ? 'Runtime.app' : 'runtime');
-const resourcesDir = process.platform === 'darwin' ? path.join(installDir, 'Contents', 'Resources') : installDir;
-
-function installXULApp() {
+function installXULApp(platform=process.platform) {
   // Copy the qbrt xulapp to the target directory.
 
   // TODO: move qbrt xulapp files into a separate source directory
   // that we can copy in one fell swoop.
 
   const sourceDir = path.join(__dirname, '..');
+  const { resourcesDir } = getPlatformDirectories(platform);
   const targetDir = path.join(resourcesDir, 'qbrt');
 
   const files = [

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -21,7 +21,7 @@ require('promise.prototype.finally').shim();
 
 const chalk = require('chalk');
 const cli = require('cli');
-const installRuntime = require('./install-runtime');
+const { installRuntime } = require('./install-runtime');
 
 let exitCode = 0;
 


### PR DESCRIPTION
This PR adds `--win` and `--linux` flags to the `package` command. I've refactored the CLI code accordingly, so that the resulting package isn't just based on your current platform.